### PR TITLE
use terraform format output in Lifecycle based ASG solution

### DIFF
--- a/.sandbox/provision/lifecycle-asg/lifecycle.sh
+++ b/.sandbox/provision/lifecycle-asg/lifecycle.sh
@@ -63,7 +63,7 @@ cat <<EOF
         "value": "$VOLUME_ID"
     },
     "instance": {
-        "value: "$INSTANCE_ID"
+        "value": "$INSTANCE_ID"
     }
 }
 EOF

--- a/.sandbox/provision/lifecycle-asg/lifecycle.sh
+++ b/.sandbox/provision/lifecycle-asg/lifecycle.sh
@@ -44,12 +44,26 @@ case "$cmd" in
 esac
 cat <<EOF 
 {
-    "sandbox_id": "$SANDBOX_ID",
-    "sandbox_name": "$SANDBOX_NAME",
-    "password": "$PASSWORD",
-    "public_dns": "$PUBLIC_DNS",
-    "public_ip": "$PUBLIC_IP",
-    "volume_id": "$VOLUME_ID",
-    "instance": "$INSTANCE_ID"
+    "sandbox_id": {
+        "value": "$SANDBOX_ID"
+    },
+    "sandbox_name": {
+        "value": "$SANDBOX_NAME"
+    },
+    "password": {
+        "value": "$PASSWORD"
+    },
+    "public_dns": {
+        "value": "$PUBLIC_DNS"
+    },
+    "public_ip": {
+        "value": "$PUBLIC_IP"
+    },
+    "volume_id": {
+        "value": "$VOLUME_ID"
+    },
+    "instance": {
+        "value: "$INSTANCE_ID"
+    }
 }
 EOF


### PR DESCRIPTION
The current lifecycle's state is in a different format from terraform's. To simplify the integration, this PR unifies the output format (to Terraform's).